### PR TITLE
Patch deprecated symbol warning from YSI

### DIFF
--- a/language.inc
+++ b/language.inc
@@ -95,7 +95,7 @@ static
 
 hook OnPlayerConnect(playerid) {
 	lang_PlayerLanguage[playerid] = 0;
-	return Y_HOOKS_CONTINUE_RETURN_1;
+	return 1;
 }
 
 stock DefineLanguageReplacement(key[], val[]) {


### PR DESCRIPTION
Lately Y_Less has made some changes to the YSI and using `Y_HOOKS_CONTINUE_RETURN 1` started throwing a warning indicating that it's now deprecated. Those changes actually apply to that whole group of defines, so it would be the best to fix other libraries as well. I'm willing to make the necessary pull requests in the next few days if you don't have time to take care of it by yourself.

The warning for reference:
```
dependencies/language/language.inc:98 (warning) function is deprecated (symbol "Y_HOOKS_CONTINUE_RETURN_1") Use `return 1;`.
```